### PR TITLE
Lab test result date fix and EditVisit form closing fix

### DIFF
--- a/Clinic/Clinic/View/EditVisitForm.cs
+++ b/Clinic/Clinic/View/EditVisitForm.cs
@@ -141,14 +141,7 @@ namespace Clinic.View
 
         private void EditVisitForm_FormClosed(object sender, FormClosedEventArgs e)
         {
-            string message = "Any information entered in this form will be lost.  " +
-               "Are you sure you want to cancel entering the visit information?";
-            string title = "Cancel Entering Visit Details";
-            var selectedOption = MessageBox.Show(message, title, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-            if (selectedOption == DialogResult.Yes)
-            {
-                this.viewVisitForm.Enabled = true;
-            }
+            this.viewVisitForm.Enabled = true;
         }
 
         /// <summary>

--- a/Clinic/Clinic/View/EnterLabTestResultForm.cs
+++ b/Clinic/Clinic/View/EnterLabTestResultForm.cs
@@ -45,7 +45,8 @@ namespace Clinic.View
         {
             this.prefillPatientNameLabel.Text = this.currentConductedLabTest.FullName; 
             this.prefillTestNameLabel.Text = this.currentConductedLabTest.LabTest.Name;
-            this.resultDateTimePicker.Value = DateTime.Now;
+            this.resultDateTimePicker.MinDate = this.referringForm.GetVisit().VisitDate;
+            this.resultDateTimePicker.Value = this.referringForm.GetVisit().VisitDate;
         }
 
         /// <summary>


### PR DESCRIPTION
Made date picker in lab result form prevent entries before appointment date and fixed the double confirmation box on closing of the edit visit form.